### PR TITLE
refactor(stepper): control own value and remove `focused`

### DIFF
--- a/src/client/components/CountStepper.js
+++ b/src/client/components/CountStepper.js
@@ -19,8 +19,8 @@ const CountStepper = ({
     min,
     max,
     enableReinitialize: true,
-    defaultValue: parseInt(field.value, 10),
-    onChange: newValue => setFieldValue(field.name, newValue),
+    defaultValue: parseInt(field.value, 10) || 1,
+    onNewValue: newValue => setFieldValue(field.name, newValue),
   });
 
   return (

--- a/src/client/use-stepper/__snapshots__/use-stepper.test.js.snap
+++ b/src/client/use-stepper/__snapshots__/use-stepper.test.js.snap
@@ -29,7 +29,7 @@ Object {
 }
 `;
 
-exports[`useStepper returns the correct values 1`] = `
+exports[`useStepper returns the correct properties 1`] = `
 Object {
   "decrement": [Function],
   "getDecrementProps": [Function],

--- a/src/client/use-stepper/__snapshots__/use-stepper.test.js.snap
+++ b/src/client/use-stepper/__snapshots__/use-stepper.test.js.snap
@@ -21,6 +21,7 @@ Object {
 exports[`useStepper provides the correct input props in getInputProps 1`] = `
 Object {
   "onBlur": [Function],
+  "onChange": [Function],
   "onFocus": [Function],
   "ref": [Function],
   "type": "text",
@@ -31,7 +32,6 @@ Object {
 exports[`useStepper returns the correct values 1`] = `
 Object {
   "decrement": [Function],
-  "focused": false,
   "getDecrementProps": [Function],
   "getFormProps": [Function],
   "getIncrementProps": [Function],

--- a/src/client/use-stepper/use-stepper.test.js
+++ b/src/client/use-stepper/use-stepper.test.js
@@ -6,7 +6,6 @@ import useStepper from './use-stepper';
 
 function Counter(props) {
   const {
-    focused,
     setValue,
     getFormProps,
     getInputProps,
@@ -19,14 +18,10 @@ function Counter(props) {
       <button data-testid="decrement" type="button" {...getDecrementProps()}>
         decrement
       </button>
-      <input
-        data-testid="input"
-        {...getInputProps({ onChange: props.onChange })}
-      />
+      <input data-testid="input" {...getInputProps()} />
       <button data-testid="increment" type="button" {...getIncrementProps()}>
         increment
       </button>
-      <span data-testid="focused">{String(focused)}</span>
       <button
         data-testid="set-value-to-42"
         type="button"
@@ -39,10 +34,9 @@ function Counter(props) {
 }
 
 function renderForm(options = {}) {
-  const onChange = options.onChange || jest.fn();
-  const renderResult = render(<Counter onChange={onChange} {...options} />);
+  const renderResult = render(<Counter {...options} />);
   const { value } = renderResult.getByTestId('input');
-  return { value, onChange, ...renderResult };
+  return { value, ...renderResult };
 }
 
 describe('useStepper', () => {
@@ -128,18 +122,6 @@ describe('useStepper', () => {
     expect(input.selectionEnd).toBe(input.value.length);
   });
 
-  it('returns the correct focused state', () => {
-    const { getByTestId } = renderForm();
-    const input = getByTestId('input');
-    const focused = getByTestId('focused');
-
-    expect(focused.textContent).toBe('false');
-
-    fireEvent.focus(input);
-
-    expect(focused.textContent).toBe('true');
-  });
-
   it('updates current value on blur', () => {
     const min = 1;
     const max = 10;
@@ -166,41 +148,13 @@ describe('useStepper', () => {
     const { getByTestId } = renderForm();
     const input = getByTestId('input');
     const form = getByTestId('form');
-    const focused = getByTestId('focused');
 
-    fireEvent.focus(input);
-    expect(focused.textContent).toBe('true');
+    input.focus();
+    expect(input).toHaveFocus();
+
     fireEvent.submit(form);
-    expect(focused.textContent).toBe('false');
-  });
 
-  it('calls onChange on blur when controlled', () => {
-    const { onChange, getByTestId } = renderForm();
-    const input = getByTestId('input');
-
-    fireEvent.focus(input);
-    fireEvent.change(input, { target: { value: '42' } });
-    fireEvent.blur(input);
-
-    expect(onChange).toHaveBeenCalledWith(42);
-  });
-
-  it('calls onChange after setValue (controlled)', () => {
-    const { onChange, getByTestId } = renderForm({ value: 33 });
-    const setValueTo42Button = getByTestId('set-value-to-42');
-
-    fireEvent.click(setValueTo42Button);
-
-    expect(onChange).toHaveBeenCalledWith(42);
-  });
-
-  it('calls onChange after setValue (uncontrolled)', () => {
-    const { onChange, getByTestId } = renderForm();
-    const setValueTo42Button = getByTestId('set-value-to-42');
-
-    fireEvent.click(setValueTo42Button);
-
-    expect(onChange).toHaveBeenCalledWith(42);
+    expect(input).not.toHaveFocus();
   });
 
   describe('enableReinitialize', () => {

--- a/src/client/use-stepper/use-stepper.test.js
+++ b/src/client/use-stepper/use-stepper.test.js
@@ -50,7 +50,7 @@ describe('useStepper', () => {
     expect(parseFloat(result.current.value)).toBe(42);
   });
 
-  it('returns the correct values', () => {
+  it('returns the correct properties', () => {
     const { result } = renderHook(() => useStepper());
     expect(result.current).toMatchSnapshot();
   });
@@ -155,6 +155,42 @@ describe('useStepper', () => {
     fireEvent.submit(form);
 
     expect(input).not.toHaveFocus();
+  });
+
+  it('calls onNewValue on blur', () => {
+    const onNewValue = jest.fn();
+    const { getByTestId } = renderForm({ onNewValue });
+    const input = getByTestId('input');
+
+    input.focus();
+    expect(onNewValue).not.toHaveBeenCalled();
+
+    input.blur();
+
+    expect(onNewValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onNewValue after calling setValue', () => {
+    const onNewValue = jest.fn();
+    const { getByTestId } = renderForm({ onNewValue });
+    const setValueTo42Button = getByTestId('set-value-to-42');
+
+    fireEvent.click(setValueTo42Button);
+
+    expect(onNewValue).toHaveBeenCalledWith(42);
+  });
+
+  it('calls onNewValue on change', () => {
+    const onNewValue = jest.fn();
+    const { getByTestId } = renderForm({ onNewValue });
+    const input = getByTestId('input');
+
+    input.focus();
+    expect(onNewValue).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: '33' } });
+
+    expect(onNewValue).toHaveBeenCalledWith(33);
   });
 
   describe('enableReinitialize', () => {

--- a/src/client/use-stepper/use-stepper.test.js
+++ b/src/client/use-stepper/use-stepper.test.js
@@ -193,6 +193,23 @@ describe('useStepper', () => {
     expect(onNewValue).toHaveBeenCalledWith(33);
   });
 
+  it('handles decimals', () => {
+    const { result } = renderHook(() =>
+      useStepper({ defaultValue: 1, step: 0.25 }),
+    );
+
+    expect(result.current.value).toBe(1);
+    act(() => result.current.decrement());
+    expect(result.current.value).toBe(0.75);
+    act(() => result.current.increment());
+    act(() => result.current.increment());
+    expect(result.current.value).toBe(1.25);
+    act(() => result.current.setValue(-0.5));
+    expect(result.current.value).toBe(-0.5);
+    act(() => result.current.decrement());
+    expect(result.current.value).toBe(-0.75);
+  });
+
   describe('enableReinitialize', () => {
     it('true: value is updated to new default if defaultValue changes and value has not been modified', () => {
       const { result, rerender } = renderHook(opts => useStepper(opts), {


### PR DESCRIPTION
This changes the implementation of the stepper hook to control its own value all the time, rather
than only when unfocused. `useStepper` now ignores the `value` option and `onChange` has been
renamed to `onNewValue` to avoid confusion with the actual `onChange` handler attached to the
input (these are not the same thing and receive different arguments when invoked). This change also
removes the `focused` return value from `useStepper` as there is no need for the hook to track this
information or provide it to the caller.