### PR TITLE
refactor(app): extract providers into AppProviders

### DIFF
--- a/src/client/App.js
+++ b/src/client/App.js
@@ -1,13 +1,13 @@
 /** @jsx jsx */
 import '@wkovacs64/normalize.css';
-import { jsx, ThemeProvider, Flex, Container } from 'theme-ui';
+import { jsx, Flex, Container } from 'theme-ui';
 import Header from './components/Header';
 import Raffle from './components/Raffle';
-import { theme } from './theme';
+import AppProviders from './AppProviders';
 
 const App = () => {
   return (
-    <ThemeProvider theme={theme}>
+    <AppProviders>
       <Flex
         sx={{
           flexDirection: 'column',
@@ -19,7 +19,7 @@ const App = () => {
           <Raffle />
         </Container>
       </Flex>
-    </ThemeProvider>
+    </AppProviders>
   );
 };
 

--- a/src/client/AppProviders.js
+++ b/src/client/AppProviders.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ThemeProvider } from 'theme-ui';
+import { theme } from './theme';
+
+const AppProviders = ({ children }) => {
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};
+
+AppProviders.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+AppProviders.displayName = 'AppProviders';
+
+export default AppProviders;

--- a/src/client/__tests__/AppProviders.test.js
+++ b/src/client/__tests__/AppProviders.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AppProviders from '../AppProviders';
+
+test('renders children', () => {
+  render(
+    <AppProviders>
+      <div>There is content here!</div>
+    </AppProviders>,
+  );
+
+  expect(screen.getByText(/content/i)).toBeInTheDocument();
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,9 +1,6 @@
-/* eslint-disable import/no-extraneous-dependencies */
-import React from 'react';
-import { ThemeProvider } from 'theme-ui';
 import { render as rtlRender } from '@testing-library/react';
-import theme from '../src/client/theme';
+import AppProviders from '../src/client/AppProviders';
 
 export const render = (ui, ...rest) => {
-  return rtlRender(<ThemeProvider theme={theme}>{ui}</ThemeProvider>, ...rest);
+  return rtlRender(ui, { wrapper: AppProviders, ...rest });
 };


### PR DESCRIPTION
This makes it easier to add providers later and take advantage of RTL's wrapper option for tests.