### PR TITLE
refactor: remove remaining specific event ID code

### DIFF
--- a/src/functions/__tests__/draw.test.js
+++ b/src/functions/__tests__/draw.test.js
@@ -3,11 +3,11 @@ import { server, rest } from '../../test/server';
 import { EVENTS_ENDPOINT } from '../../test/fixtures';
 import { handler } from '../draw';
 
-const draw = async ({ meetup, specificEventId = '', count = 1 }) =>
+const draw = async ({ meetup, count = 1 }) =>
   handler(
     {
       httpMethod: 'GET',
-      queryStringParameters: { meetup, specificEventId, count },
+      queryStringParameters: { meetup, count },
     },
     {},
   );

--- a/src/functions/draw.js
+++ b/src/functions/draw.js
@@ -14,10 +14,9 @@ const handler = async (request /* , context */) => {
 
   let meetup;
   let count;
-  let specificEventId;
 
   try {
-    ({ meetup, count, specificEventId } = getParamsFromRequest(request));
+    ({ meetup, count } = getParamsFromRequest(request));
   } catch (err) {
     return {
       headers,
@@ -27,13 +26,9 @@ const handler = async (request /* , context */) => {
   }
 
   try {
-    const baseUrl = `https://api.meetup.com/${encodeURIComponent(
+    const eventUrl = `https://api.meetup.com/${encodeURIComponent(
       meetup,
-    )}/events`;
-    const eventUrlSuffix = '?status=upcoming&only=id,visibility';
-    const eventUrl = `${baseUrl}/${encodeURIComponent(
-      specificEventId,
-    )}${eventUrlSuffix}`;
+    )}/events?status=upcoming&only=id,visibility`;
 
     const res = await fetch(eventUrl);
 

--- a/src/functions/helpers/__tests__/get-params-from-request.test.js
+++ b/src/functions/helpers/__tests__/get-params-from-request.test.js
@@ -24,30 +24,11 @@ describe('getParamsFromRequest', () => {
     ).toThrow();
   });
 
-  it('throws on invalid specificEventId', () => {
-    expect(() =>
-      getParamsFromRequest({
-        httpMethod: 'GET',
-        queryStringParameters: {
-          meetup: 'meetup',
-          specificEventId: 6,
-        },
-      }),
-    ).toThrow();
-  });
-
   it('extracts query parameters successfully', () => {
-    const queryStringParameters = {
-      meetup: 'meetup',
-      count: 4,
-      specificEventId: '1234567890',
-    };
+    const queryStringParameters = { meetup: 'meetup', count: 4 };
 
     expect(
-      getParamsFromRequest({
-        httpMethod: 'GET',
-        queryStringParameters,
-      }),
+      getParamsFromRequest({ httpMethod: 'GET', queryStringParameters }),
     ).toEqual(queryStringParameters);
   });
 });

--- a/src/functions/helpers/get-params-from-request.js
+++ b/src/functions/helpers/get-params-from-request.js
@@ -11,14 +11,12 @@ import isNumber from 'is-number';
  * @param {string} request.queryStringParameters.meetup the Meetup name
  * @param {number} [request.queryStringParameters.count] the number of winners
  * to draw (default: 1)
- * @param {string} [request.queryStringParameters.specificEventId] a Meetup
- * event ID for a specific event (default: latest upcoming/in-progress event)
  * @returns {Object} an object containing the required Meetup API parameters
  * @throws {Error} query parameters must be valid
  */
 export const getParamsFromRequest = ({
   httpMethod,
-  queryStringParameters: { meetup, count = 1, specificEventId = '' },
+  queryStringParameters: { meetup, count = 1 },
 }) => {
   if (httpMethod !== 'GET') {
     throw new Error('This API only accepts HTTP GET requests.');
@@ -34,13 +32,5 @@ export const getParamsFromRequest = ({
     throw new Error('The "count" query parameter must be a number.');
   }
 
-  if (typeof specificEventId !== 'string') {
-    throw new Error('The "specificEventId" query parameter must be a string.');
-  }
-
-  return {
-    meetup,
-    count,
-    specificEventId,
-  };
+  return { meetup, count };
 };


### PR DESCRIPTION
The UI for this feature was removed in #78, back in v4.0.0. This just removes it from the draw
function, where it was left in place just in case the feature was restored in the future. But
it won't be, so it's time to clean up.