### PR TITLE
fix: move security headers to Remix server entry point

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -14,6 +14,43 @@ export default function handleRequest(
 
   responseHeaders.set('Content-Type', 'text/html');
 
+  responseHeaders.set('X-Content-Type-Options', 'nosniff');
+  responseHeaders.set('X-Frame-Options', 'DENY');
+  responseHeaders.set('X-XSS-Protection', '1; mode=block');
+  responseHeaders.set('Expect-CT', 'enforce, max-age=3600');
+  responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  responseHeaders.set(
+    'Strict-Transport-Security',
+    'max-age=63072000; includeSubDomains; preload',
+  );
+  responseHeaders.set(
+    'Content-Security-Policy',
+    [
+      `base-uri 'none'`,
+      `frame-ancestors 'none'`,
+      `form-action 'self'`,
+      `default-src 'self'`,
+      `connect-src 'self' ${
+        process.env.NODE_ENV === 'development' ? 'ws:' : ''
+      } https://secure.meetupstatic.com https://cloudflare-ipfs.com`,
+      `img-src 'self' data: https:`,
+      `object-src 'none'`,
+      `script-src 'self' 'unsafe-inline'`,
+      `style-src 'self' 'unsafe-inline'`,
+      `worker-src 'self'`,
+    ].join('; ') + ';',
+  );
+  responseHeaders.set(
+    'Permissions-Policy',
+    [
+      'geolocation=()',
+      'camera=()',
+      'microphone=()',
+      'payment=()',
+      'usb=()',
+    ].join(', '),
+  );
+
   return new Response('<!DOCTYPE html>' + markup, {
     status: responseStatusCode,
     headers: responseHeaders,

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,14 +23,3 @@
   for = "/build/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, s-maxage=31536000"
-
-[[headers]]
-  for = "/*"
-  [headers.values]
-    X-Content-Type-Options = "nosniff"
-    X-Frame-Options = "DENY"
-    X-XSS-Protection = "1; mode=block"
-    Content-Security-Policy = "default-src 'self'; connect-src 'self' ws: https://secure.meetupstatic.com https://cloudflare-ipfs.com; img-src 'self' data: https:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; worker-src 'self'"
-    Expect-CT = "enforce, max-age=3600"
-    Referrer-Policy = "strict-origin-when-cross-origin"
-    Permissions-Policy = "geolocation=(), camera=(), microphone=(), payment=(), usb=()"


### PR DESCRIPTION
These were not being sent when in the Netlify config for some reason.